### PR TITLE
Msp crunch output

### DIFF
--- a/pymummer/alignment.py
+++ b/pymummer/alignment.py
@@ -108,3 +108,29 @@ class Alignment:
             self.ref_name,
             self.qry_name])
 
+
+    def to_msp_crunch(self):
+        '''Returns the alignment as a line in MSPcrunch format. The columns are space-separated and are:
+           1. score
+           2. percent identity
+           3. match start in the query sequence
+           4. match end in the query sequence
+           5. query sequence name
+           6. subject sequence start
+           7. subject sequence end
+           8. subject sequence name'''
+
+        # we don't know the alignment score. Estimate it. This approximates 1 for a match.
+        aln_score = int(self.percent_identity * 0.005 * (self.hit_length_ref + self.hit_length_qry))
+
+        return ' '.join(str(x) for x in [
+                aln_score,
+                '{0:.2f}'.format(self.percent_identity),
+                self.qry_start + 1,
+                self.qry_end + 1,
+                self.qry_name,
+                self.ref_start + 1,
+                self.ref_end + 1,
+                self.ref_name
+        ])
+

--- a/pymummer/tests/alignment_test.py
+++ b/pymummer/tests/alignment_test.py
@@ -121,3 +121,11 @@ class TestNucmer(unittest.TestCase):
         a = alignment.Alignment('\t'.join(l_in))
         self.assertEqual(str(a), '\t'.join(l_out))
 
+
+    def test_to_msp_crunch(self):
+        '''Test to_msp_crunch'''
+        l_in = ['100', '110', '1', '10', '10', '11', '80.00', '123', '456', '-1', '0', 'ref', 'qry']
+        a = alignment.Alignment('\t'.join(l_in))
+        expected = '8 80.00 1 10 qry 100 110 ref'
+        self.assertEqual(expected, a.to_msp_crunch())
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not found_all_progs:
 
 setup(
     name='pymummer',
-    version='0.4.0',
+    version='0.5.0',
     description='Wrapper for MUMmer',
     packages = find_packages(),
     author='Martin Hunt, Nishadi De Silva',


### PR DESCRIPTION
This adds a new method that can be used to convert mummer output to "MSPcrunch" output (which can be used as input to ACT).