### PR TITLE
Show snps expose C option

### DIFF
--- a/pymummer/nucmer.py
+++ b/pymummer/nucmer.py
@@ -26,6 +26,7 @@ class Runner:
       snps_header=True,
       verbose=False,
       promer=False,
+      show_snps_C=True,
    ):
         self.qry = query
         self.ref = ref
@@ -42,7 +43,7 @@ class Runner:
         self.snps_header = snps_header
         self.verbose = verbose
         self.use_promer = promer
-
+        self.show_snps_C = show_snps_C
 
 
     def _nucmer_command(self, ref, qry, outprefix):
@@ -97,7 +98,7 @@ class Runner:
 
 
     def _show_snps_command(self, infile, outfile):
-        command = 'show-snps -TClr'
+        command = 'show-snps -T' + ('C' if self.show_snps_C else '') + 'lr'
 
         if not self.snps_header:
             command += ' -H'

--- a/pymummer/tests/nucmer_test.py
+++ b/pymummer/tests/nucmer_test.py
@@ -55,11 +55,12 @@ class TestRunner(unittest.TestCase):
         '''test _show_snps_command'''
         tests = [
             [nucmer.Runner('ref', 'qry', 'outfile', snps_header=False), 'show-snps -TClr -H infile > outfile'],
-            [nucmer.Runner('ref', 'qry', 'outfile'), 'show-snps -TClr infile > outfile']
+            [nucmer.Runner('ref', 'qry', 'outfile'), 'show-snps -TClr infile > outfile'],
+            [nucmer.Runner('ref', 'qry', 'outfile', show_snps_C=False), 'show-snps -Tlr infile > outfile']
         ]
 
-        for l in tests:
-            self.assertEqual(l[0]._show_snps_command('infile', 'outfile'), l[1])
+        for nuc_obj, expected in tests:
+            self.assertEqual(nuc_obj._show_snps_command('infile', 'outfile'), expected)
 
 
     def test_write_script_no_snps(self):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not found_all_progs:
 
 setup(
     name='pymummer',
-    version='0.9.0',
+    version='0.10.0',
     description='Wrapper for MUMmer',
     packages = find_packages(),
     author='Martin Hunt, Nishadi De Silva',


### PR DESCRIPTION
-C was being used by default with show-snps. Add option to not use -C.