### PR TITLE
Ref qry translate vars not in matches

### DIFF
--- a/pymummer/alignment.py
+++ b/pymummer/alignment.py
@@ -159,6 +159,8 @@ class Alignment:
         for i in range(len(variant_list)):
             if variant_list[i].var_type not in {variant.INS, variant.DEL}:
                 continue
+            if not self.intersects_variant(variant_list[i]):
+                continue
             if variant_list[i].ref_start <= ref_coord <= variant_list[i].ref_end:
                 return variant_list[i].qry_start, True
             elif variant_list[i].ref_start < ref_coord:
@@ -193,6 +195,8 @@ class Alignment:
 
         for i in range(len(variant_list)):
             if variant_list[i].var_type not in {variant.INS, variant.DEL}:
+                continue
+            if not self.intersects_variant(variant_list[i]):
                 continue
             if variant_list[i].qry_start <= qry_coord <= variant_list[i].qry_end:
                 return variant_list[i].ref_start, True

--- a/pymummer/alignment.py
+++ b/pymummer/alignment.py
@@ -136,6 +136,14 @@ class Alignment:
         ])
 
 
+    def intersects_variant(self, var):
+        var_ref_coords = sorted([var.ref_start, var.ref_end])
+        var_ref_coords = pyfastaq.intervals.Interval(var_ref_coords[0], var_ref_coords[1])
+        var_qry_coords = sorted([var.qry_start, var.qry_end])
+        var_qry_coords = pyfastaq.intervals.Interval(var_qry_coords[0], var_qry_coords[1])
+        return var_ref_coords.intersects(self.ref_coords()) and var_qry_coords.intersects(self.qry_coords())
+
+
     def qry_coords_from_ref_coord(self, ref_coord, variant_list):
         '''Given a reference position and a list of variants ([variant.Variant]),
            works out the position in the query sequence, accounting for indels.

--- a/pymummer/tests/alignment_test.py
+++ b/pymummer/tests/alignment_test.py
@@ -130,6 +130,22 @@ class TestNucmer(unittest.TestCase):
         self.assertEqual(expected, a.to_msp_crunch())
 
 
+    def test_intersects_variant(self):
+        'Test intersects_variant'''
+        snp0 = snp.Snp('100\tA\t.\t600\t75\t77\t1\t0\t606\t1700\t1\t1\tref\tqry') #100 in ref, 600 in qry
+        indel = variant.Variant(snp0)
+
+        aln1 = alignment.Alignment('100\t500\t600\t1000\t501\t501\t100.00\t600\t1700\t1\t1\tref\tqry')
+        aln2 = alignment.Alignment('101\t500\t600\t1000\t501\t501\t100.00\t600\t1700\t1\t1\tref\tqry')
+        aln3 = alignment.Alignment('100\t500\t601\t1000\t501\t501\t100.00\t600\t1700\t1\t1\tref\tqry')
+        aln4 = alignment.Alignment('101\t500\t601\t1000\t501\t501\t100.00\t600\t1700\t1\t1\tref\tqry')
+
+        self.assertTrue(aln1.intersects_variant(indel))
+        self.assertFalse(aln2.intersects_variant(indel))
+        self.assertFalse(aln3.intersects_variant(indel))
+        self.assertFalse(aln4.intersects_variant(indel))
+
+
     def test_qry_coords_from_ref_coord_test_bad_ref_coord(self):
         '''Test qry_coords_from_ref_coord with bad ref coords'''
         aln = alignment.Alignment('\t'.join(['100', '200', '1', '100', '100', '100', '100.00', '300', '300', '1', '1', 'ref', 'qry']))

--- a/pymummer/tests/alignment_test.py
+++ b/pymummer/tests/alignment_test.py
@@ -257,6 +257,19 @@ class TestNucmer(unittest.TestCase):
             aln.ref_start, aln.ref_end = aln.ref_end, aln.ref_start
 
 
+    def test_qry_coords_from_ref_coord_when_variant_not_in_nucmer_match(self):
+        '''Test ref_coords_from_qry_coord when variant not in nucmer match'''
+        aln = alignment.Alignment('1\t606\t596\t1201\t606\t606\t100.00\t606\t1700\t1\t1\tref\tqry')
+        snp0 = snp.Snp('127\tA\t.\t77\t75\t77\t1\t0\t606\t1700\t1\t1\tref\tqry')
+        indel = variant.Variant(snp0)
+        self.assertEqual((595, False), aln.qry_coords_from_ref_coord(0, []))
+        self.assertEqual((595, False), aln.qry_coords_from_ref_coord(0, [indel]))
+        self.assertEqual((995, False), aln.qry_coords_from_ref_coord(400, []))
+        self.assertEqual((995, False), aln.qry_coords_from_ref_coord(400, [indel]))
+        self.assertEqual((1200, False), aln.qry_coords_from_ref_coord(605, []))
+        self.assertEqual((1200, False), aln.qry_coords_from_ref_coord(605, [indel]))
+
+
     def test_ref_coords_from_qry_coord_test_same_strand(self):
         '''Test ref_coords_from_qry_coord on same strand'''
         aln = alignment.Alignment('\t'.join(['1', '101', '100', '200', '100', '100', '100.00', '300', '300', '1', '1', 'ref', 'qry']))
@@ -306,3 +319,15 @@ class TestNucmer(unittest.TestCase):
             aln.ref_start, aln.ref_end = aln.ref_end, aln.ref_start
             aln.qry_start, aln.qry_end = aln.qry_end, aln.qry_start
 
+
+    def test_ref_coords_from_qry_coord_when_variant_not_in_nucmer_match(self):
+        '''Test ref_coords_from_qry_coord when variant not in nucmer match'''
+        aln = alignment.Alignment('1\t606\t596\t1201\t606\t606\t100.00\t606\t1700\t1\t1\tref\tqry')
+        snp0 = snp.Snp('127\tA\t.\t77\t75\t77\t1\t0\t606\t1700\t1\t1\tref\tqry')
+        indel = variant.Variant(snp0)
+        self.assertEqual((0, False), aln.ref_coords_from_qry_coord(595, []))
+        self.assertEqual((0, False), aln.ref_coords_from_qry_coord(595, [indel]))
+        self.assertEqual((400, False), aln.ref_coords_from_qry_coord(995, []))
+        self.assertEqual((400, False), aln.ref_coords_from_qry_coord(995, [indel]))
+        self.assertEqual((605, False), aln.ref_coords_from_qry_coord(1200, []))
+        self.assertEqual((605, False), aln.ref_coords_from_qry_coord(1200, [indel]))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not found_all_progs:
 
 setup(
     name='pymummer',
-    version='0.10.1',
+    version='0.10.2',
     description='Wrapper for MUMmer',
     packages = find_packages(),
     author='Martin Hunt, Nishadi De Silva',


### PR DESCRIPTION
Fixes bug when translating a coordinate between reference and query, when there is an indel that happens to not correspond to the nucmer match.