### PR TITLE
Store variant strand

### DIFF
--- a/pymummer/snp.py
+++ b/pymummer/snp.py
@@ -18,6 +18,7 @@ class Snp:
             self.qry_pos = int(l[3]) - 1
             self.ref_length = int(l[-6])
             self.qry_length = int(l[-5])
+            self.reverse = {'1': False, '-1': True}[l[-3]]
             self.ref_name = l[-2]
             self.qry_name = l[-1]
         except:
@@ -36,6 +37,7 @@ class Snp:
             self.qry_pos + 1,
             self.ref_length,
             self.qry_length,
+            '-1' if self.reverse else '1',
             self.ref_name,
             self.qry_name
         ]])

--- a/pymummer/tests/alignment_test.py
+++ b/pymummer/tests/alignment_test.py
@@ -159,16 +159,16 @@ class TestNucmer(unittest.TestCase):
     def test_qry_coords_from_ref_coord_test_same_strand(self):
         '''Test qry_coords_from_ref_coord on same strand'''
         aln = alignment.Alignment('\t'.join(['100', '200', '1', '101', '100', '100', '100.00', '300', '300', '1', '1', 'ref', 'qry']))
-        snp0 = snp.Snp('\t'.join(['140', 'A', 'T', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # snp
+        snp0 = snp.Snp('\t'.join(['140', 'A', 'T', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # snp
         snp0 = variant.Variant(snp0)
-        snp1 = snp.Snp('\t'.join(['140', 'A', '.', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
-        snp2 = snp.Snp('\t'.join(['141', 'C', '.', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
+        snp1 = snp.Snp('\t'.join(['140', 'A', '.', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
+        snp2 = snp.Snp('\t'.join(['141', 'C', '.', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
         del1 = variant.Variant(snp1)
         del2 = variant.Variant(snp1)
         self.assertTrue(del2.update_indel(snp2))
-        snp3 = snp.Snp('\t'.join(['150', '.', 'A', '50', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
-        snp4 = snp.Snp('\t'.join(['150', '.', 'C', '51', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
-        snp5 = snp.Snp('\t'.join(['150', '.', 'G', '52', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
+        snp3 = snp.Snp('\t'.join(['150', '.', 'A', '50', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
+        snp4 = snp.Snp('\t'.join(['150', '.', 'C', '51', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
+        snp5 = snp.Snp('\t'.join(['150', '.', 'G', '52', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
         ins1 = variant.Variant(snp3)
         ins2 = variant.Variant(snp3)
         self.assertTrue(ins2.update_indel(snp4))
@@ -209,16 +209,16 @@ class TestNucmer(unittest.TestCase):
     def test_qry_coords_from_ref_coord_test_different_strand(self):
         '''Test qry_coords_from_ref_coord on different strand'''
         aln = alignment.Alignment('\t'.join(['100', '200', '101', '1', '100', '100', '100.00', '300', '300', '1', '1', 'ref', 'qry']))
-        snp0 = snp.Snp('\t'.join(['140', 'A', 'T', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # snp
+        snp0 = snp.Snp('\t'.join(['140', 'A', 'T', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # snp
         snp0 = variant.Variant(snp0)
-        snp1 = snp.Snp('\t'.join(['140', 'A', '.', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
-        snp2 = snp.Snp('\t'.join(['141', 'C', '.', '40', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
+        snp1 = snp.Snp('\t'.join(['140', 'A', '.', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
+        snp2 = snp.Snp('\t'.join(['141', 'C', '.', '40', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
         del1 = variant.Variant(snp1)
         del2 = variant.Variant(snp1)
         self.assertTrue(del2.update_indel(snp2))
-        snp3 = snp.Snp('\t'.join(['150', '.', 'A', '50', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
-        snp4 = snp.Snp('\t'.join(['150', '.', 'C', '51', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
-        snp5 = snp.Snp('\t'.join(['150', '.', 'G', '52', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
+        snp3 = snp.Snp('\t'.join(['150', '.', 'A', '50', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
+        snp4 = snp.Snp('\t'.join(['150', '.', 'C', '51', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
+        snp5 = snp.Snp('\t'.join(['150', '.', 'G', '52', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
         ins1 = variant.Variant(snp3)
         ins2 = variant.Variant(snp3)
         self.assertTrue(ins2.update_indel(snp4))
@@ -273,16 +273,16 @@ class TestNucmer(unittest.TestCase):
     def test_ref_coords_from_qry_coord_test_same_strand(self):
         '''Test ref_coords_from_qry_coord on same strand'''
         aln = alignment.Alignment('\t'.join(['1', '101', '100', '200', '100', '100', '100.00', '300', '300', '1', '1', 'ref', 'qry']))
-        snp0 = snp.Snp('\t'.join(['40', 'T', 'A', '140', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # snp
+        snp0 = snp.Snp('\t'.join(['40', 'T', 'A', '140', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # snp
         snp0 = variant.Variant(snp0)
-        snp1 = snp.Snp('\t'.join(['40', '.', 'A', '140', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
-        snp2 = snp.Snp('\t'.join(['40', '.', 'C', '141', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from ref
+        snp1 = snp.Snp('\t'.join(['40', '.', 'A', '140', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
+        snp2 = snp.Snp('\t'.join(['40', '.', 'C', '141', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from ref
         del1 = variant.Variant(snp1)
         del2 = variant.Variant(snp1)
         self.assertTrue(del2.update_indel(snp2))
-        snp3 = snp.Snp('\t'.join(['50', 'A', '.', '150', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
-        snp4 = snp.Snp('\t'.join(['51', 'C', '.', '150', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
-        snp5 = snp.Snp('\t'.join(['52', 'G', '.', '150', 'x', 'x', '300', '300', 'x', 'x', 'ref', 'qry'])) # del from qry
+        snp3 = snp.Snp('\t'.join(['50', 'A', '.', '150', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
+        snp4 = snp.Snp('\t'.join(['51', 'C', '.', '150', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
+        snp5 = snp.Snp('\t'.join(['52', 'G', '.', '150', 'x', 'x', '300', '300', 'x', '1', 'ref', 'qry'])) # del from qry
         ins1 = variant.Variant(snp3)
         ins2 = variant.Variant(snp3)
         self.assertTrue(ins2.update_indel(snp4))

--- a/pymummer/tests/snp_test.py
+++ b/pymummer/tests/snp_test.py
@@ -12,13 +12,13 @@ class TestSnp(unittest.TestCase):
         '''Test __str__ with format with no -C option'''
         l_in = ['187', 'A', 'C', '269', '187', '187', '654', '853', '1', '1', 'ref_name', 'qry_name']
         s = snp.Snp('\t'.join(l_in))
-        expected = '\t'.join(['187', 'A', 'C', '269', '654', '853', 'ref_name', 'qry_name'])
+        expected = '\t'.join(['187', 'A', 'C', '269', '654', '853', '1', 'ref_name', 'qry_name'])
         self.assertEqual(str(s), expected)
 
 
     def test_str_with_c_option(self):
         '''Test __str__ with format with -C option'''
-        l_in = ['187', 'A', 'C', '269', '187', '187', '0', '0', '654', '853', '1', '1', 'ref_name', 'qry_name']
+        l_in = ['187', 'A', 'C', '269', '187', '187', '0', '0', '654', '853', '1', '-1', 'ref_name', 'qry_name']
         s = snp.Snp('\t'.join(l_in))
-        expected = '\t'.join(['187', 'A', 'C', '269', '654', '853', 'ref_name', 'qry_name'])
+        expected = '\t'.join(['187', 'A', 'C', '269', '654', '853', '-1', 'ref_name', 'qry_name'])
         self.assertEqual(str(s), expected)

--- a/pymummer/tests/variant_test.py
+++ b/pymummer/tests/variant_test.py
@@ -25,33 +25,33 @@ class TestVariant(unittest.TestCase):
     def test_update_indel_no_change(self):
         '''Test update_indel does nothing in the right cases'''
         initial_vars = [
-            snp.Snp('\t'.join(['42', 'A', 'C', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', 'C', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', 'C', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', 'C', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
         ]
 
         to_add = [
-            snp.Snp('\t'.join(['142', 'A', '.', '1000', 'x', 'x', '2000', '3000', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['142', '.', 'A', '1000', 'x', 'x', '2000', '3000', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['43', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref2', 'qry'])),
-            snp.Snp('\t'.join(['43', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry2'])),
-            snp.Snp('\t'.join(['44', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref2', 'qry'])),
-            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry2'])),
-            snp.Snp('\t'.join(['44', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
-            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['142', 'A', '.', '1000', 'x', 'x', '2000', '3000', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['142', '.', 'A', '1000', 'x', 'x', '2000', '3000', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['43', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref2', 'qry'])),
+            snp.Snp('\t'.join(['43', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry2'])),
+            snp.Snp('\t'.join(['44', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref2', 'qry'])),
+            snp.Snp('\t'.join(['43', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry2'])),
+            snp.Snp('\t'.join(['44', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
+            snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])),
         ]
 
         assert len(initial_vars) == len(to_add)
@@ -64,8 +64,8 @@ class TestVariant(unittest.TestCase):
 
     def test_update_indel_insertion(self):
         '''Test update_indel extends insertions correctly'''
-        insertion = variant.Variant(snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])))
-        to_add = snp.Snp('\t'.join(['42', '.', 'C', '101', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry']))
+        insertion = variant.Variant(snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])))
+        to_add = snp.Snp('\t'.join(['42', '.', 'C', '101', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry']))
         expected = copy.copy(insertion)
         # coords stored zero-based, so subtract 1 from the real expected coords
         expected.ref_start = 41
@@ -84,8 +84,8 @@ class TestVariant(unittest.TestCase):
 
     def test_update_indel_deletion(self):
         '''Test update_indel extends deletions correctly'''
-        deletion = variant.Variant(snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry'])))
-        to_add = snp.Snp('\t'.join(['43', 'C', '.', '100', 'x', 'x', '300', '400', 'x', 'x', 'ref', 'qry']))
+        deletion = variant.Variant(snp.Snp('\t'.join(['42', 'A', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])))
+        to_add = snp.Snp('\t'.join(['43', 'C', '.', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry']))
         expected = copy.copy(deletion)
         # coords stored zero-based, so subtract 1 from the real expected coords
         expected.ref_start = 41

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not found_all_progs:
 
 setup(
     name='pymummer',
-    version='0.10.3',
+    version='0.11.0',
     description='Wrapper for MUMmer',
     packages = find_packages(),
     author='Martin Hunt, Nishadi De Silva',


### PR DESCRIPTION
When there is a variant, mummer reports whether the alignment between the query and reference that gave rise to the variant needs the query reverse complementing. This PR makes changes to store this strand information. Previously it was not being stored.