### PR TITLE
Store reverse or not in Variant class

### DIFF
--- a/pymummer/tests/variant_test.py
+++ b/pymummer/tests/variant_test.py
@@ -64,8 +64,8 @@ class TestVariant(unittest.TestCase):
 
     def test_update_indel_insertion(self):
         '''Test update_indel extends insertions correctly'''
-        insertion = variant.Variant(snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry'])))
-        to_add = snp.Snp('\t'.join(['42', '.', 'C', '101', 'x', 'x', '300', '400', 'x', '1', 'ref', 'qry']))
+        insertion = variant.Variant(snp.Snp('\t'.join(['42', '.', 'A', '100', 'x', 'x', '300', '400', 'x', '-1', 'ref', 'qry'])))
+        to_add = snp.Snp('\t'.join(['42', '.', 'C', '101', 'x', 'x', '300', '400', 'x', '-1', 'ref', 'qry']))
         expected = copy.copy(insertion)
         # coords stored zero-based, so subtract 1 from the real expected coords
         expected.ref_start = 41

--- a/pymummer/variant.py
+++ b/pymummer/variant.py
@@ -37,6 +37,7 @@ class Variant:
         self.qry_end = snp.qry_pos
         self.qry_length = snp.qry_length
         self.qry_name = snp.qry_name
+        self.reverse = snp.reverse
 
 
     def __eq__(self, other):
@@ -54,7 +55,8 @@ class Variant:
             str(self.qry_end + 1),
             str(self.qry_length),
             str(self.qry_name),
-            self.qry_base
+            self.qry_base,
+            '-1' if self.reverse else '1',
         ])
 
     def update_indel(self, nucmer_snp):
@@ -63,7 +65,8 @@ class Variant:
         if self.var_type not in [INS, DEL] \
           or self.var_type != new_variant.var_type \
           or self.qry_name != new_variant.qry_name \
-          or self.ref_name != new_variant.ref_name:
+          or self.ref_name != new_variant.ref_name \
+          or self.reverse != new_variant.reverse:
             return False
         if self.var_type == INS \
           and self.ref_start == new_variant.ref_start \


### PR DESCRIPTION
Previous PR stored strand info for Snps (ie one line of mummer output). This adds the strand info to Variants (ie multiple lines of mummer output, specifically indels). 