### PR TITLE
Add Python Versions and Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+    - amd64
+    - ppc64le
 addons:
   apt:
     packages:
@@ -9,8 +12,12 @@ cache:
   - "build"
   - "$HOME/.cache/pip"
 python:
-  - "3.3"
+# - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 sudo: false
 install:
   - "source ./install_dependencies.sh"


### PR DESCRIPTION
Added Multiple python versions and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.