### PR TITLE
allow the user to specify temp dir or use the system default

### DIFF
--- a/pymummer/nucmer.py
+++ b/pymummer/nucmer.py
@@ -136,7 +136,7 @@ class Runner:
         qry = os.path.abspath(self.qry)
         ref = os.path.abspath(self.ref)
         outfile = os.path.abspath(self.outfile)
-        tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.', dir=os.getcwd())
+        tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.')
         original_dir = os.getcwd()
         os.chdir(tmpdir)
         script = 'run_nucmer.sh'


### PR DESCRIPTION
I ran into the following issue trying to use the Seroba docker container

```
Traceback (most recent call last):
  File "/usr/local/bin/seroba", line 88, in <module>
    args.func(args)
  File "/usr/local/lib/python3.8/site-packages/seroba/tasks/sero_run.py", line 19, in run
    sero.run()
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 481, in run
    self._prediction(assemblie_file,cluster)
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 452, in _prediction
    self.sero, self.imp = Serotyping._find_serotype(assemblie_file,serogroup_fasta,self.meta_data_dict[serogroup],\
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 261, in _find_serotype
    pymummer.nucmer.Runner(
  File "/usr/local/lib/python3.8/site-packages/pymummer/nucmer.py", line 139, in run
    tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.', dir=os.getcwd())
  File "/usr/local/lib/python3.8/tempfile.py", line 358, in mkdtemp
    _os.mkdir(file, 0o700)
PermissionError: [Errno 13] Permission denied: '/tmp.run_nucmer.727hfrey'
```

This PR allows `tempfile` to figure out where to make the temp dir (see https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)

```
Python searches a standard list of directories to find one which the calling user can create files in. The list is:

The directory named by the TMPDIR environment variable.
The directory named by the TEMP environment variable.
The directory named by the TMP environment variable.
A platform-specific location:
    - On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order
    - On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.

As a last resort, the current working directory.
```